### PR TITLE
fixed class declaration in persistent_memory_client.hpp

### DIFF
--- a/contributors.md
+++ b/contributors.md
@@ -1,3 +1,4 @@
 # Contributors to this library
 
 * **Raphael Van Hoffelen** -*work*- Helped set up repo and its architecture
+* **Ben Quan** -*work*- Currently maintaining repo

--- a/inc/persistent_memory_client.hpp
+++ b/inc/persistent_memory_client.hpp
@@ -8,7 +8,7 @@
 
 /*
   Name: persistent_memory_client.hpp
-  Last update: 9/19/2022 by Ben Quan 
+  Last update: 10/31/2022 by Ben Quan 
   Author: Matthew Piccoli
   Contributors: Ben Quan, Raphael Van Hoffelen
 */
@@ -20,9 +20,9 @@
 
 const uint8_t kTypePersistentMemory  =   11;
 
-class PowerMonitorClient: public ClientAbstract{
+class PersistentMemoryClient: public ClientAbstract{
   public:
-    PowerMonitorClient(uint8_t obj_idn):
+    PersistentMemoryClient(uint8_t obj_idn):
       ClientAbstract(     kTypePersistentMemory, obj_idn),
       erase_(             kTypePersistentMemory, obj_idn, kSubErase),
       revert_to_default_( kTypePersistentMemory, obj_idn, kSubRevertToDefault),


### PR DESCRIPTION
- renamed class declaration from PowerMonitorClient to PersistentMemoryClient in persistent_memory_client.hpp